### PR TITLE
One fix and one new feature

### DIFF
--- a/DKCarouselView/DKCarouselView.h
+++ b/DKCarouselView/DKCarouselView.h
@@ -54,6 +54,9 @@ typedef void(^DKCarouselViewDidChangeBlock)(DKCarouselView *view, NSInteger inde
 // set infinite slide or not, defaults to NO.
 @property (nonatomic, assign, getter = isFinite) BOOL finite;
 
+// set selected page index
+@property (nonatomic, assign) NSUInteger selectedPage;
+
 - (void)setItems:(NSArray *)items;
 
 // auto paging.

--- a/DKCarouselView/DKCarouselView.m
+++ b/DKCarouselView/DKCarouselView.m
@@ -206,6 +206,17 @@ typedef void(^DKCarouselViewTapBlock)();
     return [self.pageControl sizeForNumberOfPages:self.pageControl.numberOfPages];
 }
 
+- (void)setSelectedPage: (NSUInteger)selectedPage {
+    self.pageControl.currentPage = self.currentPage = selectedPage;
+    if (self.carouselItemViews.count > selectedPage){
+        if (self.finite) {
+            [self.scrollView setContentOffset:CGPointMake(kScrollViewFrameWidth * selectedPage, 0) animated:YES];
+        }else{
+            [self setupViews];
+        }
+    }
+}
+
 -(void)setItems:(NSArray *)items {
     if (items == nil) return;
     
@@ -219,7 +230,7 @@ typedef void(^DKCarouselViewTapBlock)();
     _items = [items copy];
     
     self.pageControl.numberOfPages = _items.count;
-    self.pageControl.currentPage = self.currentPage = 0;
+    self.pageControl.currentPage = self.currentPage;
     
     _scrollView.scrollEnabled = _items.count > 1;
     

--- a/DKCarouselView/DKCarouselView.m
+++ b/DKCarouselView/DKCarouselView.m
@@ -402,10 +402,10 @@ typedef void(^DKCarouselViewTapBlock)();
             self.currentPage = GetNextIndex();
         }
         [self setupViews];
-        
-        if (self.didChangeBlock != nil) {
-            self.didChangeBlock(self, self.currentPage);
-        }
+    }
+    
+    if (self.didChangeBlock != nil) {
+        self.didChangeBlock(self, self.currentPage);
     }
     
     self.pageControl.currentPage = self.currentPage;


### PR DESCRIPTION
Fix: `scrollViewDidEndDecelerating` did not fire `didChangeBlock` when `finite="true"`. 
New: Added `selectedPage` property to allow for a custom defined selected index.